### PR TITLE
Add PilotSessionUI Sdk

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,7 +17,19 @@ android {
 }
 
 dependencies {
+    // Add both TeamViewerSdk and PilotSessionUI AAR files:
     implementation fileTree(include: 'TeamViewerSdk.aar', dir: 'libs')
+    implementation fileTree(include: 'PilotSessionUI.aar', dir: 'libs')
+
+    // Add dependencies of PilotSessionUI.aar:
+    runtimeOnly "androidx.camera:camera-camera2:1.0.0-beta12"
+    runtimeOnly "androidx.camera:camera-lifecycle:1.0.0-beta12"
+    runtimeOnly "androidx.constraintlayout:constraintlayout:2.0.4"
+    runtimeOnly "androidx.fragment:fragment-ktx:1.2.3"
+    runtimeOnly "androidx.lifecycle:lifecycle-livedata-ktx:2.2.0"
+    runtimeOnly "com.google.android.material:material:1.1.0"
+    runtimeOnly "de.javagl:obj:0.3.0"
+    runtimeOnly "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.4.10"
 
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.fragment:fragment:1.2.5'

--- a/app/src/main/java/com/teamviewer/example/travel/ScreenSharingWrapper.java
+++ b/app/src/main/java/com/teamviewer/example/travel/ScreenSharingWrapper.java
@@ -71,7 +71,7 @@ public final class ScreenSharingWrapper {
                     Log.e("TeamViewerSdk", "Error: " + errorCode);
                     Toast.makeText(context, errorCode.toString(), Toast.LENGTH_SHORT).show();
                 })
-                .withSessionCallback(new SessionCallbackImpl(inputCallback))
+                .withSessionCallback(new SessionCallbackImpl(context, inputCallback))
                 .withAuthenticationCallback(new AuthenticationCallbackImpl(context))
                 .withSettings(m_settings)
                 .withAccessControlCallback(new AccessControlCallbackImpl(context))

--- a/app/src/main/java/com/teamviewer/example/travel/callbacks/SessionCallbackImpl.java
+++ b/app/src/main/java/com/teamviewer/example/travel/callbacks/SessionCallbackImpl.java
@@ -8,26 +8,36 @@
 
 package com.teamviewer.example.travel.callbacks;
 
+import android.content.Context;
+
 import com.teamviewer.example.travel.ScreenSharingWrapper;
+import com.teamviewer.sdk.pilotsessionui.PilotSessionUI;
+import com.teamviewer.sdk.screensharing.PilotSession;
 import com.teamviewer.sdk.screensharing.SessionCallback;
 import com.teamviewer.sdk.screensharing.TeamViewerSession;
 
 public class SessionCallbackImpl implements SessionCallback {
 
+    private final Context m_context;
     private final InputCallbackImpl m_inputCallback;
 
-    public SessionCallbackImpl(InputCallbackImpl inputCallback)
-    {
+    public SessionCallbackImpl(Context context, InputCallbackImpl inputCallback) {
+        m_context = context;
         m_inputCallback = inputCallback;
     }
 
     @Override
     public void onSessionStarted(TeamViewerSession teamViewerSession) {
+        if (teamViewerSession instanceof PilotSession) {
+            PilotSessionUI.INSTANCE.setCurrentSession((PilotSession) teamViewerSession);
+            m_context.startActivity(PilotSessionUI.INSTANCE.createIntentForPilotSessionActivity(m_context));
+        }
         ScreenSharingWrapper.getInstance().sessionStarted();
     }
 
     @Override
     public void onSessionEnded() {
+        PilotSessionUI.INSTANCE.setCurrentSession(null);
         ScreenSharingWrapper.getInstance().sessionEnded();
         m_inputCallback.terminate();
     }


### PR DESCRIPTION
This commits adds the TeamViewer Sdk for the PilotSessionUI to the
TravelApp.

When the TeamViewer Sdk connects to a session code created for Pilot
\- also known as Augmented Reality (AR) - it will create a corresponding
Pilot session instead of a screen sharing session. In this case we will
show the Pilot Session UI provided by the new Sdk from TeamViewer.